### PR TITLE
jackknife

### DIFF
--- a/jackknify/JAXknife.py
+++ b/jackknify/JAXknife.py
@@ -10,7 +10,6 @@ def run(xw,yw,dw,w,csize,rng):
     flips[:xw.shape[0]//2] = -1.00
     rng.shuffle(flips)
     
-    print(dw.shape,xw.shape)
     return image(xw,yw,dw*flips,w,csize)
 
 def image(x,y,c,w,csize):

--- a/jackknify/JAXknife.py
+++ b/jackknify/JAXknife.py
@@ -1,0 +1,21 @@
+import jax; jax.config.update('jax_enable_x64',True)
+import jax.numpy as jp
+
+import jax_finufft
+
+import numpy as np
+
+def run(xw,yw,dw,w,csize,rng):
+    flips = np.ones(xw.shape[0])
+    flips[:xw.shape[0]//2] = -1.00
+    rng.shuffle(flips)
+    
+    print(dw.shape,xw.shape)
+    return image(xw,yw,dw*flips,w,csize)
+
+def image(x,y,c,w,csize):
+    x = jp.append(x,-x)
+    y = jp.append(y,-y)
+    w = jp.append(w, w)
+    c = jp.append(c,c.conj())
+    return jax_finufft.nufft1((csize,csize),c*w/np.sum(w),x,y).real

--- a/jackknify/Main.py
+++ b/jackknify/Main.py
@@ -144,6 +144,11 @@ class Jack:
         os.system('rm -rf {0}.residual'.format(self.outfile))
         os.system('rm -rf {0}.image'.format(self.outfile))
         os.system('rm -rf {0}.sumwt'.format(self.outfile))
+
+    def knife(self,
+              samples: int = 1,
+              seed: int = 42):
+        return self.run(samples,seed)
     
     def run(self, 
             samples: int = 1,

--- a/jackknify/Main.py
+++ b/jackknify/Main.py
@@ -8,6 +8,8 @@ from .ImSettings import *
 from .MsManager import MSmanager
 from .Plot import SLP, IMAGE
 
+from . import JAXknife
+
 class Jack:
     def __init__(self, 
                  fname: str, 
@@ -142,7 +144,7 @@ class Jack:
         os.system('rm -rf {0}.residual'.format(self.outfile))
         os.system('rm -rf {0}.image'.format(self.outfile))
         os.system('rm -rf {0}.sumwt'.format(self.outfile))
-        
+    
     def run(self, 
             samples: int = 1,
             seed: int = 42
@@ -164,6 +166,31 @@ class Jack:
                     
             os.system('rm -vf *.last')
             os.system('rm -vf *.log')
+
+            if i != samples-1:
+                clear_output(True)
+
+    def gofast(self,
+               samples: int = 1,
+               seed: int = 42):
+        print('.. Loading in MS')
+        _, UVreal, UVimag, UVwgts, uw, vw = self.manager.uvdata_loader()
+        
+        rng = np.random.default_rng(seed=seed)
+
+        cdelt = np.deg2rad(self.imcase.cellsize/3.60E+03)
+        xw = -2.00*np.pi*vw*cdelt
+        yw =  2.00*np.pi*uw*cdelt
+
+        print('.. Running JAXknife')
+        for i in tqdm.tqdm(range(0,samples,1)):
+            img = JAXknife.run(xw,yw,UVreal+1j*UVimag,UVwgts,self.imcase.imsize,rng)
+
+            os.system(f'mkdir -p {self.outdir}jaxknife/')
+            outpath = self.vis_jacked.split('/')[-1]
+            outpath = f'{self.outdir}jaxknife/{outpath}_jax_samp_{i:05d}'
+
+            np.savez_compressed(outpath,img)
 
             if i != samples-1:
                 clear_output(True)

--- a/jackknify/MsManager.py
+++ b/jackknify/MsManager.py
@@ -65,14 +65,14 @@ class MSmanager:
                 vwave  = vwave.flatten()
                                 
                 uvwght = (shapes*uvwght.reshape(1,-1)).flatten()
-              
+
                 uvdist  = np.append(uvdist, (uwave**2 + vwave**2)**0.5*1e-3)
                 UVreal  = np.append(UVreal,  uvreal)
                 UVimag  = np.append(UVimag,  uvimag)
                 uvwghts = np.append(uvwghts, uvwght)
-                us      = np.append(us, u) 
-                vs      = np.append(vs, v)
-
+                us      = np.append(us, uwave) 
+                vs      = np.append(vs, vwave)
+    
         return uvdist, UVreal, UVimag, uvwghts, us, vs
     
     def model_to_ms(self, model, sigma = None):


### PR DESCRIPTION
I integrated the ['jaxknife'](https://github.com/lucadimascolo/jaxknife) independent implementation in `jackknify`. 

It uses `jax` and `jax_finufft` as main backends. 
Future developments might comprise a better JITing of the imaging function and the possibility of exporting the maps to MS file.